### PR TITLE
Add the serde `default` option for non-required struct fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -70,7 +70,7 @@ pub struct {{{classname}}} {
     {{#description}}
     /// {{{.}}}
     {{/description}}
-    #[serde(rename = "{{{baseName}}}"{{^required}}{{#isNullable}}, default, with = "::serde_with::rust::double_option"{{/isNullable}}{{/required}}{{^required}}, skip_serializing_if = "Option::is_none"{{/required}}{{#required}}{{#isNullable}}, deserialize_with = "Option::deserialize"{{/isNullable}}{{/required}})]
+    #[serde(rename = "{{{baseName}}}"{{^required}}, default{{#isNullable}}, with = "::serde_with::rust::double_option"{{/isNullable}}{{/required}}{{^required}}, skip_serializing_if = "Option::is_none"{{/required}}{{#required}}{{#isNullable}}, deserialize_with = "Option::deserialize"{{/isNullable}}{{/required}})]
     pub {{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{^required}}Option<{{/required}}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{{dataType}}}{{/isModel}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^required}}>{{/required}},
 {{/vars}}
 }


### PR DESCRIPTION
[Serde option `default`](https://serde.rs/attr-default.html) should be present for _all_ non-required fields.  It should _especially_ be present for non-nullable fields that are not `required`, because the presence of `nullable` speaks  to the _value_ of the field, not whether it is present.  However, a field not being in the `required` list means that the field need not even be present, necessitating the `serde([...]default` option.

This is critical for enabling communication on APIs where a field may or may not be present.

e.g.
```
     #                                vvvvvvvvvvvvvv
     foo = fields.Str(required=False, dump_only=True)
     #                ^^^^^^^^^^^^^^
```